### PR TITLE
Add a basic smoke test and fix PrintedContent optimization

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/util/IgnoreCloseOutputStream.java
+++ b/src/main/java/com/cloudbees/jenkins/support/util/IgnoreCloseOutputStream.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 /**
- * Provides a {@link FilterInputStream} that ignores calls to close its underlying stream and instead simply flushes it.
+ * Provides a {@link FilterOutputStream} that ignores calls to close its underlying stream and instead simply flushes it.
  *
  * @since TODO
  */

--- a/src/main/java/com/cloudbees/jenkins/support/util/IgnoreCloseWriter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/util/IgnoreCloseWriter.java
@@ -33,7 +33,7 @@ import java.io.IOException;
 import java.io.Writer;
 
 /**
- * Provides a {@link FilterWriter} that ignores calls to close its underlying stream and instead simply flushes it.
+ * Provides a {@link FilterWriter} that ignores calls to close its underlying writer and instead simply flushes it.
  *
  * @since TODO
  */

--- a/src/main/java/com/cloudbees/jenkins/support/util/IgnoreCloseWriter.java
+++ b/src/main/java/com/cloudbees/jenkins/support/util/IgnoreCloseWriter.java
@@ -28,27 +28,23 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import javax.annotation.Nonnull;
-import java.io.FilterOutputStream;
+import java.io.FilterWriter;
 import java.io.IOException;
-import java.io.OutputStream;
+import java.io.Writer;
 
 /**
- * Provides a {@link FilterInputStream} that ignores calls to close its underlying stream and instead simply flushes it.
+ * Provides a {@link FilterWriter} that ignores calls to close its underlying stream and instead simply flushes it.
  *
  * @since TODO
  */
 @Restricted(NoExternalUse.class)
-public final class IgnoreCloseOutputStream extends FilterOutputStream {
-    public IgnoreCloseOutputStream(@Nonnull OutputStream out) {
+public final class IgnoreCloseWriter extends FilterWriter {
+    public IgnoreCloseWriter(@Nonnull Writer out) {
         super(out);
     }
 
     @Override
     public void close() throws IOException {
         flush();
-    }
-
-    public OutputStream getUnderlyingStream() {
-        return out;
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
@@ -4,29 +4,44 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 
 import com.cloudbees.jenkins.support.api.Component;
+import com.cloudbees.jenkins.support.filter.ContentFilters;
+import com.cloudbees.jenkins.support.filter.ContentMappings;
+import com.cloudbees.jenkins.support.impl.AboutJenkins;
 import com.cloudbees.jenkins.support.util.SystemPlatform;
 import com.gargoylesoftware.htmlunit.Page;
 import com.gargoylesoftware.htmlunit.html.HtmlButton;
 import com.gargoylesoftware.htmlunit.html.HtmlForm;
 import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import hudson.util.IOUtils;
+import hudson.ExtensionList;
+import hudson.model.Label;
+import hudson.model.Slave;
 import hudson.util.RingBufferLogHandler;
+import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
+import org.junit.rules.TemporaryFolder;
 import org.xml.sax.SAXException;
 
 import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.zip.ZipFile;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -34,6 +49,9 @@ import java.util.zip.ZipFile;
 public class SupportActionTest {
     @Rule
     public JenkinsRule rule = new JenkinsRule();
+
+    @Rule
+    public TemporaryFolder temp = new TemporaryFolder();
 
     @Inject
     SupportAction root;
@@ -56,7 +74,7 @@ public class SupportActionTest {
     private void downloadBundle(String s) throws IOException, SAXException {
         JenkinsRule.JSONWebResponse jsonWebResponse = rule.postJSON(root.getUrlName() + s, "");
         File zipFile = File.createTempFile("test", "zip");
-        IOUtils.copy(jsonWebResponse.getContentAsStream(), zipFile);
+        IOUtils.copy(jsonWebResponse.getContentAsStream(), Files.newOutputStream(zipFile.toPath()));
         ZipFile z = new ZipFile(zipFile);
         // Zip file is valid
     }
@@ -87,7 +105,7 @@ public class SupportActionTest {
             HtmlButton submit = (HtmlButton) form.getHtmlElementsByTagName("button").get(0);
             Page zip = submit.click();
             File zipFile = File.createTempFile("test", "zip");
-            IOUtils.copy(zip.getWebResponse().getContentAsStream(), zipFile);
+            IOUtils.copy(zip.getWebResponse().getContentAsStream(), Files.newOutputStream(zipFile.toPath()));
 
             ZipFile z = new ZipFile(zipFile);
 
@@ -131,6 +149,32 @@ public class SupportActionTest {
                     fail(r.getMessage());
                 }
             }
+        }
+    }
+
+    @Test
+    public void anonymizationSmokes() throws Exception {
+        Slave node = rule.createSlave(Label.get("super_secret_node"));
+        File bundleFile = temp.newFile();
+        List<Component> componentsToCreate = Collections.singletonList(ExtensionList.lookup(Component.class).get(AboutJenkins.class));
+        try (OutputStream os = Files.newOutputStream(bundleFile.toPath())) {
+            ContentFilters.get().setEnabled(false);
+            SupportPlugin.writeBundle(os, componentsToCreate);
+            ZipFile zip = new ZipFile(bundleFile);
+            String nodeComponentText = IOUtils.toString(zip.getInputStream(zip.getEntry("nodes.md")), StandardCharsets.UTF_8);
+            assertThat("Node name should be present when anonymization is disabled",
+                    nodeComponentText, containsString(node.getNodeName()));
+        }
+        try (OutputStream os = Files.newOutputStream(bundleFile.toPath())) {
+            ContentFilters.get().setEnabled(true);
+            SupportPlugin.writeBundle(os, componentsToCreate);
+            ZipFile zip = new ZipFile(bundleFile);
+            String nodeComponentText = IOUtils.toString(zip.getInputStream(zip.getEntry("nodes.md")), StandardCharsets.UTF_8);
+            assertThat("Node name should not be present when anonymization is enabled",
+                    nodeComponentText, not(containsString(node.getNodeName())));
+            String anonymousNodeName = ContentMappings.get().getMappings().get(node.getNodeName());
+            assertThat("Anonymous node name should be present when anonymization is enabled",
+                    nodeComponentText, containsString(anonymousNodeName));
         }
     }
 }

--- a/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/SupportActionTest.java
@@ -165,6 +165,7 @@ public class SupportActionTest {
             assertThat("Node name should be present when anonymization is disabled",
                     nodeComponentText, containsString(node.getNodeName()));
         }
+        bundleFile = temp.newFile();
         try (OutputStream os = Files.newOutputStream(bundleFile.toPath())) {
             ContentFilters.get().setEnabled(true);
             SupportPlugin.writeBundle(os, componentsToCreate);

--- a/src/test/java/com/cloudbees/jenkins/support/util/IgnoreCloseWriterTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/util/IgnoreCloseWriterTest.java
@@ -24,31 +24,30 @@
 
 package com.cloudbees.jenkins.support.util;
 
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
-import javax.annotation.Nonnull;
-import java.io.FilterOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
+import java.io.Writer;
 
-/**
- * Provides a {@link FilterInputStream} that ignores calls to close its underlying stream and instead simply flushes it.
- *
- * @since TODO
- */
-@Restricted(NoExternalUse.class)
-public final class IgnoreCloseOutputStream extends FilterOutputStream {
-    public IgnoreCloseOutputStream(@Nonnull OutputStream out) {
-        super(out);
+import static org.mockito.BDDMockito.then;
+
+@RunWith(MockitoJUnitRunner.class)
+public class IgnoreCloseWriterTest {
+
+    @Mock
+    private Writer out;
+
+    @Test
+    public void shouldFlushInsteadOfClose() throws IOException {
+        IgnoreCloseWriter stream = new IgnoreCloseWriter(out);
+
+        stream.close();
+
+        then(out).should().flush();
+        then(out).shouldHaveNoMoreInteractions();
     }
 
-    @Override
-    public void close() throws IOException {
-        flush();
-    }
-
-    public OutputStream getUnderlyingStream() {
-        return out;
-    }
 }


### PR DESCRIPTION
We probably want a test for the PrintedContent trick since it would be easy to break it without realizing in the future if the order of the streams change again. Maybe we can do something with Mockito?