### PR TITLE
Fix generation of dynamic stop words

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
+++ b/src/main/java/com/cloudbees/jenkins/support/SupportPlugin.java
@@ -341,6 +341,7 @@ public class SupportPlugin extends Plugin {
             ContentFilter filter = ContentFilter.ALL;
             ContentMappings mappings = ContentMappings.get();
             try (BulkChange change = new BulkChange(mappings)) {
+                mappings.reload();
                 filter.reload();
                 change.commit();
             }

--- a/src/test/java/com/cloudbees/jenkins/support/filter/ContentMappingsTest.java
+++ b/src/test/java/com/cloudbees/jenkins/support/filter/ContentMappingsTest.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.cloudbees.jenkins.support.filter;
+
+import hudson.model.FreeStyleProject;
+import java.util.Locale;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+public class ContentMappingsTest { 
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+    
+    @Test
+    public void dynamicStopWordsAreAddedWhenReloading() throws Exception {
+        FreeStyleProject job = r.createFreeStyleProject();
+        String[] expectedStopWords = {
+            job.getPronoun().toLowerCase(Locale.ENGLISH), 
+            job.getTaskNoun().toLowerCase(Locale.ENGLISH) 
+        };
+        ContentMappings mappings = ContentMappings.get();
+        assertThat(mappings.getStopWords(), not(hasItems(expectedStopWords)));
+        mappings.reload();
+        assertThat(mappings.getStopWords(), hasItems(expectedStopWords));
+    }
+}


### PR DESCRIPTION
I noticed the issue while looking through code coverage reports: `ExtensionList.lookup(AbstractItem.class)` doesn't work because `Item` and its subclasses use the Descriptor/Describable system and are not singletons.

I probably recommended the previous code, sorry!