### PR TITLE
Add stop word, simplify serialized form of ContentMapping, and save ContentMappings after inserting mapping

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/support/filter/ContentMapping.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/ContentMapping.java
@@ -112,18 +112,16 @@ public class ContentMapping implements ContentFilter {
     private Object writeReplace() {
         SerializationProxy proxy = new SerializationProxy();
         proxy.original = original;
-        proxy.pattern = pattern;
         proxy.replacement = replacement;
         return proxy;
     }
 
     private static class SerializationProxy {
         private String original;
-        private Pattern pattern;
         private String replacement;
 
         private Object readResolve() {
-            return new ContentMapping(original, pattern, replacement);
+            return ContentMapping.of(original, replacement);
         }
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/support/filter/ContentMappings.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/ContentMappings.java
@@ -121,14 +121,13 @@ public class ContentMappings extends ManagementLink implements Saveable, Iterabl
      * Looks up or creates a new ContentMapping for the given original string and a ContentMapping generator.
      */
     public @Nonnull ContentMapping getMappingOrCreate(@Nonnull String original, @Nonnull Function<String, ContentMapping> generator) {
-        return mappings.computeIfAbsent(original, generator.andThen(mapping -> {
-            try {
-                save();
-            } catch (IOException e) {
-                LOGGER.log(Level.WARNING, "Could not save mappings file", e);
-            }
-            return mapping;
-        }));
+        ContentMapping mapping = mappings.computeIfAbsent(original, generator);
+        try {
+            save();
+        } catch (IOException e) {
+            LOGGER.log(Level.WARNING, "Could not save mappings file", e);
+        }
+        return mapping;
     }
 
     public void reload() {

--- a/src/main/java/com/cloudbees/jenkins/support/filter/ContentMappings.java
+++ b/src/main/java/com/cloudbees/jenkins/support/filter/ContentMappings.java
@@ -99,7 +99,7 @@ public class ContentMappings extends ManagementLink implements Saveable, Iterabl
                 "jenkins", "node", "master", "computer",
                 "item", "label", "view", "all", "unknown",
                 "user", "anonymous", "authenticated",
-                "everyone", "system"
+                "everyone", "system", "admin"
         ));
     }
 


### PR DESCRIPTION
Simplifying the serialized form is ok since generating the `Pattern` is deterministic, right?